### PR TITLE
Fix versions for wicket and maven plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,20 @@
 		<module>wicket6-resource-management</module>
         <module>file-upload</module>
     </modules>
+    <build>
+    	<pluginManagement>
+    		<plugins>
+    			<plugin>
+	    			<groupId>org.apache.maven.plugins</groupId>
+    				<artifactId>maven-resources-plugin</artifactId>
+    				<version>2.6</version>
+    			</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>2.3.1</version>
+				</plugin>
+    		</plugins>
+    	</pluginManagement>
+    </build>
 </project>

--- a/request-mappers/pom.xml
+++ b/request-mappers/pom.xml
@@ -12,7 +12,7 @@
   <url>http://maven.apache.org</url>
 
   	<properties>
-		<wicket.version>1.5-SNAPSHOT</wicket.version>
+		<wicket.version>1.5.9</wicket.version>
 		<jetty.version>7.2.2.v20101205</jetty.version>
 	</properties>
 


### PR DESCRIPTION
Examples were no longer building. These changes make them build with mvn and work in Eclipse.

wicket 1.5-SNAPSHOT is replaced with 1.5.9. Some maven plugin versions
were not available in maven central, those were upgraded to versions
that are found in the central.
