### PR TITLE
Change data-type url to urlstrict for urlvalidator

### DIFF
--- a/wicket-parsley-validation/src/main/java/com/mycompany/parsley/ParsleyUrlValidator.java
+++ b/wicket-parsley-validation/src/main/java/com/mycompany/parsley/ParsleyUrlValidator.java
@@ -12,6 +12,6 @@ public class ParsleyUrlValidator extends ParsleyValidationBehavior<String>
 		super(new UrlValidator());
 
 		require(true);
-		type("url");
+		type("urlstrict");
 	}
 }


### PR DESCRIPTION
If value 'www.wicket.org' is entered the clientside validation works but on the serverside a strict check is performed (scheme is mandatory) and this causes the serverside validation to fail but on the clientside you don't see anything.

... thinking about this: If this was intended behaviour this should be documented somewhere ;-)

Signed-off-by: Andreas Kuhtz andreas.kuhtz@gmail.com
